### PR TITLE
Add ability to start/stop sites by name (not just ID)

### DIFF
--- a/src/commands/start-site.ts
+++ b/src/commands/start-site.ts
@@ -1,5 +1,6 @@
 import {Command} from '@oclif/command'
 import createGraphQLClient, {gql} from '../helpers/graphql-client'
+import getSiteId from '../helpers/get-site-id'
 import Table = require('cli-table')
 
 export default class StartSite extends Command {
@@ -17,6 +18,14 @@ export default class StartSite extends Command {
 
   async run() {
     const {args} = this.parse(StartSite)
+
+    // Automatic name lookup
+    var siteName = args.siteID;
+    if(getSiteId(siteName)){
+      var siteID = getSiteId(args.siteID);
+      console.log('Automatically found SiteID for ' + siteName + ' = ' + siteID )
+      args.siteID = siteID
+    }
 
     const query = gql`
       mutation ($siteID: ID!) {

--- a/src/commands/start-site.ts
+++ b/src/commands/start-site.ts
@@ -29,16 +29,23 @@ export default class StartSite extends Command {
     `
 
     const client = createGraphQLClient()
-    const data = await client.request(query, {
-      siteID: args.siteID,
-    })
 
-    const table = new Table({
-      head: ['ID', 'Name', 'Status'],
-    })
+    try {
+      const data = await client.request(query, {
+        siteID: args.siteID,
+      })
 
-    table.push(Object.values(data.startSite))
+      const table = new Table({
+        head: ['ID', 'Name', 'Status'],
+      })
 
-    this.log(table.toString())
+      table.push(Object.values(data.startSite))
+
+      this.log(table.toString())
+    } catch(error) {
+      console.error("\n⚠️  Something went wrong! Are you sure the site ID is correct? \n")
+      console.error(JSON.stringify(error, undefined, 2))
+      process.exit(1)
+    }
   }
 }

--- a/src/commands/stop-site.ts
+++ b/src/commands/stop-site.ts
@@ -27,17 +27,23 @@ export default class StopSite extends Command {
       `
 
       const client = createGraphQLClient()
-      const data = await client.request(query, {
-        siteID: args.siteID,
-      })
+      try {
+        const data = await client.request(query, {
+          siteID: args.siteID,
+        })
 
-      const table = new Table({
-        head: ['ID', 'Name', 'Status'],
-      })
+        const table = new Table({
+          head: ['ID', 'Name', 'Status'],
+        })
 
-      table.push(Object.values(data.stopSite))
+        table.push(Object.values(data.stopSite))
 
-      this.log(table.toString())
+        this.log(table.toString())
+      } catch(error) {
+        console.error("\n⚠️  Something went wrong! Are you sure the site ID is correct? \n")
+        console.error(JSON.stringify(error, undefined, 2))
+        process.exit(1)
+      }
     }
 }
 

--- a/src/commands/stop-site.ts
+++ b/src/commands/stop-site.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@oclif/command'
 import Table = require('cli-table')
+import getSiteId from '../helpers/get-site-id'
 import createGraphQLClient, {gql} from '../helpers/graphql-client'
 
 export default class StopSite extends Command {
@@ -15,6 +16,14 @@ export default class StopSite extends Command {
 
     async run() {
       const {args} = this.parse(StopSite)
+
+      // Automatic name lookup
+      var siteName = args.siteID;
+      if(getSiteId(siteName)){
+        var siteID = getSiteId(args.siteID);
+        console.log('Automatically found SiteID for ' + siteName + ' = ' + siteID )
+        args.siteID = siteID
+      }
 
       const query = gql`
           mutation ($siteID: ID!) {

--- a/src/helpers/get-site-id.ts
+++ b/src/helpers/get-site-id.ts
@@ -1,0 +1,19 @@
+import * as fs from 'fs-extra'
+import untildify = require('untildify');
+
+export default function getSiteId(siteName: string) {
+  const sitesJsonFile = untildify('~/Library/Application Support/Local/sites.json')
+  try {
+    const sitesJson = fs.readJsonSync(sitesJsonFile)
+    for (const siteID in sitesJson) {
+      if (sitesJson.hasOwnProperty(siteID)) {
+        if (siteName === sitesJson[siteID].name) {
+          return siteID
+        }
+      }
+    }
+    return false
+  } catch (error) {
+    throw new Error('Sites info not found. Please ensure that Local is running.')
+  }
+}


### PR DESCRIPTION
This PR adds the ability to start/stop sites by using their name in the CLI. 

It'll compare the input with Local's `sites.json` file to see if there's a match by name, and return the ID if so.

Also added some basic error handling when the GraphQL Request is not successful.