### PR TITLE
Add windows support for getConnectionInfo

### DIFF
--- a/src/helpers/get-connection-info.ts
+++ b/src/helpers/get-connection-info.ts
@@ -9,7 +9,12 @@ export interface ConnectionInfo {
 }
 
 export default function getConnectionInfo(): ConnectionInfo {
-  const connectionInfoPath = untildify('~/Library/Application Support/Local/graphql-connection-info.json')
+  let connectionInfoPath;
+	if ( process.platform == 'darwin' ) {
+    connectionInfoPath = untildify('~/Library/Application Support/Local/graphql-connection-info.json');
+	} else {
+    connectionInfoPath = process.env.APPDATA + '\\Local\\graphql-connection-info.json';
+	}
 
   try {
     return fs.readJsonSync(connectionInfoPath)


### PR DESCRIPTION
This change changes the file path for windows installs. It is tested and works on Windows 11 from within an npm script.
I don't have the ability to test if this breaks on MacOS, so be sure to test.